### PR TITLE
Skip Intro Feature

### DIFF
--- a/config/defaults.js
+++ b/config/defaults.js
@@ -44,7 +44,7 @@ const defaults = {
   default_sync_mode: 'cleanseek',
 
   slplayer_plex_timeline_update_interval: 10000,
-  slplayer_controls_visible_checker_interval: 500,
+  slplayer_controls_visible_checker_interval: 250,
 
   // Controlls the max time difference cutoff for syncing by changing the playback speed
   slplayer_speed_sync_max_diff: 10000,

--- a/src/player/index.js
+++ b/src/player/index.js
@@ -25,11 +25,6 @@ export const setVolume = (volume) => {
 export const play = () => getPlayer().getMediaElement().play();
 export const pause = () => getPlayer().getMediaElement().pause();
 
-// eslint-disable-next-line no-underscore-dangle
-export const areControlsShown = () => getOverlay().getControls().enabled_
-    && (getOverlay().getControls().getControlsContainer().getAttribute('shown') != null
-    || getOverlay().getControls().getControlsContainer().getAttribute('casting') != null);
-
 export const isTimeInBufferedRange = (timeMs) => {
   const bufferedTimeRange = getPlayer().getMediaElement().buffered;
 

--- a/src/store/modules/plexclients/getters.js
+++ b/src/store/modules/plexclients/getters.js
@@ -79,4 +79,10 @@ export default {
     : false),
 
   GET_LAST_PLAY_MEDIA_COMMAND_ID: (state) => state.lastPlayMediaCommandId,
+
+  GET_ACTIVE_MEDIA_METADATA_MARKERS: (state, getters) => getters
+    .GET_ACTIVE_MEDIA_METADATA?.Marker || [],
+
+  GET_ACTIVE_MEDIA_METADATA_INTRO_MARKER: (state, getters) => getters
+    .GET_ACTIVE_MEDIA_METADATA_MARKERS.find((marker) => marker.type === 'intro'),
 };

--- a/src/store/modules/plexservers/actions.js
+++ b/src/store/modules/plexservers/actions.js
@@ -89,7 +89,10 @@ export default {
         includeStations: 1,
         includeExternalMedia: 1,
         asyncAugmentMetadata: 1,
+        asyncRefreshLocalMediaAgent: 1,
+        asyncRefreshAnalysis: 1,
         checkFiles: 1,
+        includeMarkers: 1,
       },
       signal,
     });

--- a/src/store/modules/slplayer/actions.js
+++ b/src/store/modules/slplayer/actions.js
@@ -3,13 +3,16 @@ import CAF from 'caf';
 import guid from '@/utils/guid';
 import { fetchJson, queryFetch, makeUrl } from '@/utils/fetchutils';
 import {
-  play, pause, getDurationMs, areControlsShown, getCurrentTimeMs, isTimeInBufferedRange,
+  play, pause, getDurationMs, getCurrentTimeMs, isTimeInBufferedRange,
   isMediaElementAttached, isPlaying, isPresentationPaused, isBuffering, getVolume, isPaused,
   waitForMediaElementEvent, destroy, cancelTrickPlay, load, setPlaybackRate, getPlaybackRate,
   setCurrentTimeMs, setVolume, addEventListener, removeEventListener,
-  getSmallPlayButton, getBigPlayButton, unload,
+  getSmallPlayButton, getBigPlayButton, unload, addMediaElementEventListener,
+  removeMediaElementEventListener,
 } from '@/player';
-import { destroySubtitles, setSubtitleUrl, destroyAss } from '@/player/state';
+import {
+  destroySubtitles, setSubtitleUrl, destroyAss, areControlsShown, resizeSubtitleContainer,
+} from '@/player/state';
 import Deferred from '@/utils/deferredpromise';
 
 export default {
@@ -350,6 +353,7 @@ export default {
       dispatch('START_PERIODIC_PLEX_TIMELINE_UPDATE');
     } catch (e) {
       if (getters.GET_PLAYER_INITIALIZED_DEFERRED_PROMISE) {
+        // TODO: potentially close player
         getters.GET_PLAYER_INITIALIZED_DEFERRED_PROMISE.reject(e);
         commit('SET_PLAYER_INITIALIZED_DEFERRED_PROMISE', null);
       }
@@ -373,6 +377,7 @@ export default {
   DESTROY_PLAYER_STATE: async ({ commit, dispatch }) => {
     console.debug('DESTROY_PLAYER_STATE');
     commit('STOP_UPDATE_PLAYER_CONTROLS_SHOWN_INTERVAL');
+    commit('UPDATE_PLAYER_CONTROLS_SHOWN', false);
     await dispatch('UNREGISTER_PLAYER_EVENTS');
     await dispatch('CANCEL_PERIODIC_PLEX_TIMELINE_UPDATE');
 
@@ -461,5 +466,9 @@ export default {
     dispatch('START_PERIODIC_PLEX_TIMELINE_UPDATE');
 
     await dispatch('plexclients/UPDATE_ACTIVE_PLAY_QUEUE', null, { root: true });
+  },
+
+  SKIP_INTRO: () => {
+    console.debug('SKIP_INTRO');
   },
 };

--- a/src/store/modules/slplayer/actions.js
+++ b/src/store/modules/slplayer/actions.js
@@ -7,11 +7,10 @@ import {
   isMediaElementAttached, isPlaying, isPresentationPaused, isBuffering, getVolume, isPaused,
   waitForMediaElementEvent, destroy, cancelTrickPlay, load, setPlaybackRate, getPlaybackRate,
   setCurrentTimeMs, setVolume, addEventListener, removeEventListener,
-  getSmallPlayButton, getBigPlayButton, unload, addMediaElementEventListener,
-  removeMediaElementEventListener,
+  getSmallPlayButton, getBigPlayButton, unload,
 } from '@/player';
 import {
-  destroySubtitles, setSubtitleUrl, destroyAss, areControlsShown, resizeSubtitleContainer,
+  destroySubtitles, setSubtitleUrl, destroyAss, areControlsShown,
 } from '@/player/state';
 import Deferred from '@/utils/deferredpromise';
 
@@ -468,7 +467,11 @@ export default {
     await dispatch('plexclients/UPDATE_ACTIVE_PLAY_QUEUE', null, { root: true });
   },
 
-  SKIP_INTRO: () => {
+  SKIP_INTRO: ({ commit, rootGetters }) => {
     console.debug('SKIP_INTRO');
+    const introEnd = rootGetters['plexclients/GET_ACTIVE_MEDIA_METADATA_INTRO_MARKER'].endTimeOffset;
+
+    commit('SET_OFFSET_MS', introEnd);
+    setCurrentTimeMs(introEnd);
   },
 };

--- a/src/store/modules/slplayer/state.js
+++ b/src/store/modules/slplayer/state.js
@@ -7,7 +7,7 @@ const state = () => ({
   mediaIndex: 0,
   offsetMs: 0,
   playerState: 'stopped',
-  playerControlsShown: true,
+  playerControlsShown: false,
   playerControlsShownInterval: null,
   bufferingEventListener: null,
   clickEventListener: null,

--- a/src/views/slplayer.vue
+++ b/src/views/slplayer.vue
@@ -24,9 +24,11 @@
           @volumechange="HANDLE_PLAYER_VOLUME_CHANGE"
           @enterpictureinpicture="HANDLE_PICTURE_IN_PICTURE_CHANGE"
           @leavepictureinpicture="HANDLE_PICTURE_IN_PICTURE_CHANGE"
+          @timeupdate="handleTimeUpdate"
         />
 
         <v-btn
+          v-if="AM_I_HOST && isInIntro"
           absolute
           bottom
           right
@@ -184,6 +186,8 @@ export default {
 
   data() {
     return {
+      videoTimeStamp: 0,
+
       playerConfig: {
         streaming: {
           // TODO: make this config
@@ -191,7 +195,7 @@ export default {
 
           retryParameters: {
             timeout: 0, // timeout in ms, after which we abort; 0 means never
-            maxAttempts: 9999, // the maximum number of requests before we fail
+            maxAttempts: 10, // the maximum number of requests before we fail
             baseDelay: 1000, // the base delay in ms between retries
             backoffFactor: 2, // the multiplicative backoff factor between retries
             fuzzFactor: 0.5, // the fuzz factor to apply to each retry delay
@@ -201,7 +205,7 @@ export default {
         manifest: {
           retryParameters: {
             timeout: 0, // timeout in ms, after which we abort; 0 means never
-            maxAttempts: 9999, // the maximum number of requests before we fail
+            maxAttempts: 10, // the maximum number of requests before we fail
             baseDelay: 1000, // the base delay in ms between retries
             backoffFactor: 2, // the multiplicative backoff factor between retries
             fuzzFactor: 0.5, // the fuzz factor to apply to each retry delay
@@ -228,6 +232,7 @@ export default {
 
     ...mapGetters('plexclients', [
       'GET_ACTIVE_MEDIA_METADATA',
+      'GET_ACTIVE_MEDIA_METADATA_INTRO_MARKER',
     ]),
 
     ...mapGetters('plexservers', [
@@ -240,6 +245,12 @@ export default {
           'margin-bottom': `${getControlsOffset(this.$refs?.videoPlayerContainer?.offsetHeight)}px`,
         }
         : {};
+    },
+
+    isInIntro() {
+      return this.GET_ACTIVE_MEDIA_METADATA_INTRO_MARKER
+        && this.videoTimeStamp >= this.GET_ACTIVE_MEDIA_METADATA_INTRO_MARKER.startTimeOffset
+        && this.videoTimeStamp < this.GET_ACTIVE_MEDIA_METADATA_INTRO_MARKER.endTimeOffset;
     },
   },
 
@@ -385,6 +396,10 @@ export default {
           blur: 2,
         }),
       );
+    },
+
+    handleTimeUpdate({ timeStamp }) {
+      this.videoTimeStamp = timeStamp;
     },
   },
 };

--- a/src/views/slplayer.vue
+++ b/src/views/slplayer.vue
@@ -25,6 +25,19 @@
           @enterpictureinpicture="HANDLE_PICTURE_IN_PICTURE_CHANGE"
           @leavepictureinpicture="HANDLE_PICTURE_IN_PICTURE_CHANGE"
         />
+
+        <v-btn
+          absolute
+          bottom
+          right
+          large
+          class="skip-intro"
+          :class="ARE_PLAYER_CONTROLS_SHOWN ? 'above-controls' : null"
+          :style="skipIntroButtonStyle"
+          @click="SKIP_INTRO"
+        >
+          Skip Intro
+        </v-btn>
       </div>
 
       <v-fade-transition
@@ -154,7 +167,7 @@
 import { mapActions, mapGetters, mapMutations } from 'vuex';
 import sizing from '@/mixins/sizing';
 import initialize from '@/player/init';
-import { resizeSubtitleContainer } from '@/player/state';
+import { resizeSubtitleContainer, getControlsOffset } from '@/player/state';
 
 import 'shaka-player/dist/controls.css';
 import 'libjass/libjass.css';
@@ -220,6 +233,14 @@ export default {
     ...mapGetters('plexservers', [
       'GET_MEDIA_IMAGE_URL',
     ]),
+
+    skipIntroButtonStyle() {
+      return this.ARE_PLAYER_CONTROLS_SHOWN
+        ? {
+          'margin-bottom': `${getControlsOffset(this.$refs?.videoPlayerContainer?.offsetHeight)}px`,
+        }
+        : {};
+    },
   },
 
   watch: {
@@ -238,6 +259,10 @@ export default {
       },
       immediate: true,
     },
+
+    ARE_PLAYER_CONTROLS_SHOWN() {
+      resizeSubtitleContainer();
+    },
   },
 
   async mounted() {
@@ -253,12 +278,12 @@ export default {
     await this.INIT_PLAYER_STATE();
 
     window.addEventListener('keyup', this.onKeyUp);
-    window.addEventListener('resize', resizeSubtitleContainer);
+    window.addEventListener('resize', this.resizeSubtitles);
   },
 
   beforeDestroy() {
     window.removeEventListener('keyup', this.onKeyUp);
-    window.removeEventListener('resize', resizeSubtitleContainer);
+    window.removeEventListener('resize', this.resizeSubtitles);
     this.DESTROY_PLAYER_STATE();
   },
 
@@ -279,6 +304,7 @@ export default {
       'DESTROY_PLAYER_STATE',
       'PLAY_PAUSE_VIDEO',
       'SEND_PARTY_PLAY_PAUSE',
+      'SKIP_INTRO',
     ]),
 
     ...mapMutations([
@@ -409,6 +435,15 @@ export default {
     vertical-align: middle;
     margin-left: auto;
     margin-right: auto;
+  }
+
+  .skip-intro {
+    transition-timing-function: cubic-bezier(0.55, 0.06, 0.68, 0.19);
+    transition: margin 250ms;
+  }
+
+  .skip-intro.above-controls {
+    transition-timing-function: cubic-bezier(0.22, 0.61, 0.36, 1);
   }
 </style>
 


### PR DESCRIPTION
Addresses the feature request samcm/synclounge#211
Adds skip intro button to web player while intro is being played. Note, you have to have a Plex pass and have had intro's scanned on the media for it to work (same requirements as for Plex)