### PR TITLE
ci(dependabot): remove versioning-strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    versioning-strategy: increase
     open-pull-requests-limit: 10
     commit-message:
       prefix: "ci(action)"
@@ -22,7 +21,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    versioning-strategy: increase
     open-pull-requests-limit: 10
     commit-message:
       prefix: "build(docker)"


### PR DESCRIPTION
I am disappointed dependabot does not support this. It's trying to upgrade an action from v1.X.X to just v2 and that will lose the semver granularity.